### PR TITLE
enable global cache & central mirror

### DIFF
--- a/rtran-maven/src/main/scala/com/ebay/rtran/maven/MavenModel.scala
+++ b/rtran-maven/src/main/scala/com/ebay/rtran/maven/MavenModel.scala
@@ -36,7 +36,7 @@ import scala.util.matching.Regex
 import scala.util.{Failure, Success, Try}
 
 
-case class MultiModuleMavenModel(modules: List[MavenModel]) extends IModel {
+case class MultiModuleMavenModel(rootPom: File, modules: List[MavenModel]) extends IModel {
   lazy val (parents, subModules) = modules.partition(_.localParent.isEmpty)
 }
 
@@ -177,7 +177,7 @@ class MultiModuleMavenModelProvider extends IModelProvider[MultiModuleMavenModel
         } filter {m =>
           !keys.contains(m.pomFile)
         }
-        MultiModuleMavenModel(unprocessedParents ++ modules)
+        MultiModuleMavenModel(projectCtx.rootPomFile, unprocessedParents ++ modules)
       case Failure(e) => throw e
     }
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.1-SNAPSHOT"
+version in ThisBuild := "0.8.2-SNAPSHOT"


### PR DESCRIPTION
UaaS added a set of rules for replacing bouncy castle related jars against 2.5.7 and above, they’re really expensive because they need to go through the transitive dependencies. 

As observed, we should fix:
1) Use global maven cache, currently cache is only available at the scope of each job (origin maven repo: temp/job_id/maven-repo => ~/maven-repo).
2) Most artifacts are downloaded from maven-central,  mirror of central is not benefited, support of central mirror via: maven_central_mirror in config file