### PR TITLE
change from user.home back to user.dir

### DIFF
--- a/rtran-maven/src/main/scala/com/ebay/rtran/maven/util/MavenUtil.scala
+++ b/rtran-maven/src/main/scala/com/ebay/rtran/maven/util/MavenUtil.scala
@@ -95,7 +95,7 @@ object MavenUtil {
   private lazy val remoteSnapshotRepositories: List[RemoteRepository] =
     remoteRepositories.filter(_.getPolicy(true).isEnabled)
 
-  private[maven] lazy val localRepository = new File(System.getProperty("user.home"), config.getString("local-repository"))
+  private[maven] lazy val localRepository = new File(System.getProperty("user.dir"), config.getString("local-repository"))
 
   def repositorySystemSession: RepositorySystemSession = {
     val session = MavenRepositorySystemUtils.newSession


### PR DESCRIPTION
new VMs of Staging pools has disabled access to user.home
roll back to use user.dir, the maven-repo can be shared across deployments.