### PR TITLE
throw exception in rule execution to fail fast

### DIFF
--- a/rtran-core/src/main/scala/com/ebay/rtran/core/RuleEngine.scala
+++ b/rtran-core/src/main/scala/com/ebay/rtran/core/RuleEngine.scala
@@ -47,7 +47,7 @@ class RuleEngine extends LazyLogging {
         val result = Try(rule transform model) match {
           case Success(newModel) => newModel
           case Failure(e) => logger.error("Failed execute rule {} on model {}, {}", rule.id, model, e)
-            model
+            throw e
         }
         provider save result
       case None => logger.error("Cannot find provider for {} used in rule {}", rule.rutimeModelClass, rule.id)


### PR DESCRIPTION
This is for https://jirap.corp.ebay.com/browse/RAPTOR-13898
Originally if any rule failed, the errors will be only shown in the log md file as part of the pull request. The truth is we cannot expect the pull request is correct if rule execution failed, thus changed to throw exception immediately.